### PR TITLE
Add output directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository provides helper scripts to create input data for the [SWAN](http
 
 ## Overview
 - `python/make_SWANforcing_fromwrfout.py` extracts wind information from WRF output files and converts it into the SWAN forcing format. The script also generates a GIF animation to visualize the wind fields.
-- `python/make_grid_bathy.py` reads GEBCO bathymetry and interactively generates a curvilinear grid and bathymetry files for SWAN. A template `.swn` file is printed and written to `../00_outputdata/`.
+- `python/make_grid_bathy.py` reads GEBCO bathymetry and interactively generates a curvilinear grid and bathymetry files for SWAN. A template `.swn` file is printed and written under the specified output directory (default: `../00_outputdata/`).
 - `run/runswan_timelog.sh` launches SWAN with MPI, logging execution time to a timestamped log file.
 - `setup_env.sh` creates a Python virtual environment and installs the required Python packages.
 
@@ -18,8 +18,8 @@ This repository provides helper scripts to create input data for the [SWAN](http
 2. Activate the environment with `source .venv/bin/activate` before running the Python scripts.
 
 ## Usage
-1. Edit the paths in `python/make_SWANforcing_fromwrfout.py` to point to your WRF output files. Run the script to produce `INPGRID_WIND_for_SWAN.txt` and related files under `../00_outputdata/`.
-2. Execute `python/make_grid_bathy.py` and follow the prompts to define the target grid. The bathymetry and grid files will be created in `../00_outputdata/`.
+1. Edit the paths in `python/make_SWANforcing_fromwrfout.py` to point to your WRF output files. Run the script to produce `INPGRID_WIND_for_SWAN.txt` and related files. Use `--output-dir` to change the destination (default: `../00_outputdata/`).
+2. Execute `python/make_grid_bathy.py` and follow the prompts to define the target grid. The bathymetry and grid files will be created in the directory specified by `--output-dir` (default: `../00_outputdata/`).
 3. Use the generated files in your SWAN setup and run the model via `bash run/runswan_timelog.sh <mpi_num> <swan_input>`.
 
 ## Directory Structure
@@ -33,7 +33,7 @@ README.md  # This file
 ## Proposed Improvements
 The current scripts work but require manual editing and contain Japanese comments. Future tasks include:
 - Translate all comments and messages into English for easier collaboration.
-- Add command-line arguments to specify file paths instead of hard-coding them.
+- Add command-line arguments to specify file paths instead of hard-coding them (the scripts now accept `--output-dir`).
 - Provide docstrings and usage examples for each script.
 - Include automated tests for the data generation steps.
 - Add a license file and contribution guidelines.

--- a/python/make_SWANforcing_fromwrfout.py
+++ b/python/make_SWANforcing_fromwrfout.py
@@ -1,6 +1,8 @@
+import argparse
+import os
+import shutil
 import xarray as xr
 import matplotlib.pyplot as plt
-import shutil, os
 import csv
 import glob
 import numpy as np
@@ -9,6 +11,19 @@ import matplotlib.colors as mcolors
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import pandas as pd
+
+parser = argparse.ArgumentParser(
+    description="Generate SWAN wind forcing files from WRF output"
+)
+parser.add_argument(
+    "--output-dir",
+    default="../00_outputdata",
+    help="Directory to store generated SWAN wind files",
+)
+args = parser.parse_args()
+
+output_dir = args.output_dir
+os.makedirs(output_dir, exist_ok=True)
 
 # 1. Data preparation and CSV aggregation
 print("Current working directory:", os.getcwd())
@@ -26,7 +41,8 @@ u10_list = []
 v10_list = []
 time_list = []
 
-with open('../00_outputdata/SWAN_wind_timeseries_JEBI.win', 'w', newline='') as csvfile:
+wind_csv = os.path.join(output_dir, 'SWAN_wind_timeseries_JEBI.win')
+with open(wind_csv, 'w', newline='') as csvfile:
     writer = csv.writer(csvfile, delimiter='\t')
     for i, f in enumerate(file_list, 1):
         fname = os.path.basename(f)
@@ -163,7 +179,7 @@ def update(frame):
     return []
 
 anim = FuncAnimation(fig, update, frames=wind_speed.shape[0], interval=400, blit=False)
-anim.save('../00_outputdata/wind_composite.gif', writer=PillowWriter(fps=2))
+anim.save(os.path.join(output_dir, 'wind_composite.gif'), writer=PillowWriter(fps=2))
 plt.close(fig)
 print("Saved contourf + quiver wind animation!")
 
@@ -194,7 +210,7 @@ else:
     dt_val = int(dt_seconds)
     dt_unit = 'SEC'
 
-wind_file = '../00_outputdata/SWAN_wind_timeseries.win'
+wind_file = os.path.join(output_dir, 'SWAN_wind_timeseries.win')
 
 # Display grid origin information
 origin_lon = float(lons[0,0])
@@ -235,7 +251,10 @@ swan_inpgrid_text = (
 
 print(swan_inpgrid_text)
 
-with open("../00_outputdata/INPGRID_WIND_for_SWAN.txt", 'w', encoding='utf-8') as f:
+swan_out = os.path.join(output_dir, 'INPGRID_WIND_for_SWAN.txt')
+with open(swan_out, 'w', encoding='utf-8') as f:
     f.write(swan_inpgrid_text)
 
-print("Saved SWAN output section (INPGRID WIND + OUTPUT settings) to ../00_outputdata/INPGRID_WIND_for_SWAN.txt.")
+print(
+    f"Saved SWAN output section (INPGRID WIND + OUTPUT settings) to {swan_out}."
+)

--- a/python/make_grid_bathy.py
+++ b/python/make_grid_bathy.py
@@ -1,3 +1,5 @@
+import argparse
+import os
 import xarray as xr
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator
@@ -5,9 +7,22 @@ import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap, BoundaryNorm
 
 # Script to generate SWAN bathymetry from GEBCO
-swn_file = "../00_outputdata/INPGRID_GRID_for_SWAN.txt"
-bot_file = "../00_outputdata/SWAN_output.bot"
-grd_file = "../00_outputdata/SWAN_output.grd"
+parser = argparse.ArgumentParser(
+    description="Generate SWAN bathymetry and grid files from GEBCO"
+)
+parser.add_argument(
+    "--output-dir",
+    default="../00_outputdata",
+    help="Directory to store generated grid and bathymetry files",
+)
+args = parser.parse_args()
+
+output_dir = args.output_dir
+os.makedirs(output_dir, exist_ok=True)
+
+swn_file = os.path.join(output_dir, "INPGRID_GRID_for_SWAN.txt")
+bot_file = os.path.join(output_dir, "SWAN_output.bot")
+grd_file = os.path.join(output_dir, "SWAN_output.grd")
 bot_file_swn = "./SWAN_output.bot"
 grd_file_swn = "./SWAN_output.grd"
 


### PR DESCRIPTION
## Summary
- add `--output-dir` option to `make_grid_bathy.py`
- add `--output-dir` option to `make_SWANforcing_fromwrfout.py`
- document the new argument in the README

## Testing
- `python -m py_compile python/make_grid_bathy.py python/make_SWANforcing_fromwrfout.py`

------
https://chatgpt.com/codex/tasks/task_b_6854ec802b44832fb02af791f54754d9